### PR TITLE
Fix for rust-lang@b12a3582b113c0f9c217f6311ec0d47fd0f79016

### DIFF
--- a/src/protobuf_init.rs
+++ b/src/protobuf_init.rs
@@ -14,7 +14,7 @@ struct ExprParser;
 impl RHSParser for ExprParser {
     type RHS = P<ast::Expr>;
     fn parse(&mut self, parser: &mut Parser) -> PResult<Self::RHS> {
-        parser.parse_expr_nopanic()
+        parser.parse_expr()
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -122,7 +122,7 @@ impl <'a,'b, T : RHSParser> MacroParser<'a,'b, T> {
     }
 
     pub fn parse_macro(&mut self) -> PResult<(P<ast::Expr>, Message<T::RHS>)> {
-        let expr = try!(self.parser.parse_expr_nopanic());
+        let expr = try!(self.parser.parse_expr());
         try!(self.parser.expect(&token::Comma));
         let msg = try!(self.parse_message());
         try!(self.parser.expect(&token::Eof));


### PR DESCRIPTION
Here's a tiny fix to make it compile with recent nightlies of rust-lang.
