### PR TITLE
Inits `ast::local` with empty attrs arg

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -38,6 +38,7 @@ impl <T : AstBuilder> AstBuilderExt for T {
             init: Some(ex),
             id: ast::DUMMY_NODE_ID,
             span: sp,
+            attrs: None,
         });
 
         let decl = respan(sp, ast::DeclLocal(local));


### PR DESCRIPTION
Cost of living on the edge ;)

Was previously throwing this error...

```
lawrencejones at MacBookPro in .../Projects/rust-protobuf-macros on (master)
λ ~> rustc --version
rustc 1.7.0-nightly (110df043b 2015-12-13)
lawrencejones at MacBookPro in .../Projects/rust-protobuf-macros on (master)
λ ~> cargo build
   Compiling protobuf_macros v0.1.0 (file:///Users/lawrencejones/Desktop/Projects/rust-protobuf-macros)
src/util.rs:35:23: 41:10 error: missing field `attrs` in initializer of `syntax::ast::Local` [E0063]
src/util.rs:35         let local = P(ast::Local {
src/util.rs:36             pat: pat,
src/util.rs:37             ty: None,
src/util.rs:38             init: Some(ex),
src/util.rs:39             id: ast::DUMMY_NODE_ID,
src/util.rs:40             span: sp,
               ...
src/util.rs:35:23: 41:10 help: run `rustc --explain E0063` to see a detailed explanation
error: aborting due to previous error
Could not compile `protobuf_macros`.
```
